### PR TITLE
Add job syncing with main repo, running once an hour.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,23 @@
+
+name: Merge upstream branches
+on:
+  schedule:
+    - cron:  '7 * * * *'
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Merge upstream
+        run: |
+          git config --global user.name 'Katka92'
+          git config --global user.email 'kkanova@redhat.com'
+          # "git checkout master" is unnecessary, already here by default
+          git pull --unshallow  # this option is very important, you would get
+                                # complains about unrelated histories without it.
+                                # (but actions/checkout@v2 can also be instructed
+                                # to fetch all git depth right from the start)
+          git remote add upstream https://github.com/redhat-appstudio/infra-deployments.git
+          git fetch upstream
+          git merge upstream/main
+          git push origin main


### PR DESCRIPTION
Set up a Github action that will sync our fork with the main repo.
The sync will happen once an hour. My creds will be used for it.
https://issues.redhat.com/browse/HAC-3495
