### PR TITLE
Secure the Pact broker routes

### DIFF
--- a/components/hac-pact-broker/route.yaml
+++ b/components/hac-pact-broker/route.yaml
@@ -12,3 +12,5 @@ spec:
     name: pact-broker
     weight: 100
   wildcardPolicy: None
+  tls:
+    termination: edge


### PR DESCRIPTION
Add tls to the route to make it secure. 
Issue: [HAC-3714](https://issues.redhat.com/browse/HAC-3714)