### PR TITLE
Don't set up branch automatically

### DIFF
--- a/components/hac-pact-broker/pactbroker.yaml
+++ b/components/hac-pact-broker/pactbroker.yaml
@@ -63,6 +63,8 @@ spec:
           value: "8080"
         - name: PACT_BROKER_PUBLIC_HEARTBEAT
           value: "true"
+        - name: PACT_BROKER_USE_FIRST_TAG_AS_BRANCH
+          value: "false"
         image: pactfoundation/pact-broker:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Set up env var for Pact Broker so the branch is not automatically added to the contract.
Part of https://issues.redhat.com/browse/HAC-2988
