### PR TITLE
Remove monitoring from the dev deployment.

### DIFF
--- a/components/monitoring/prometheus/development/kustomization.yaml
+++ b/components/monitoring/prometheus/development/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
 - cluster-monitoring-config.yaml
 - dummy-service-service-monitor.yaml
 - dummy-service.yaml
-- monitoringstack/
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
Removing monitoring to enable `observability-operator` to work properly on the OSD cluster.
Discussed an agreed with the monitoring team on [Slack](https://redhat-internal.slack.com/archives/C04FDFTF8EB/p1687781639684169).