### PR TITLE
allow public read

### DIFF
--- a/components/hac-pact-broker/pactbroker.yaml
+++ b/components/hac-pact-broker/pactbroker.yaml
@@ -45,16 +45,8 @@ spec:
             secretKeyRef:
               key: pact_broker_admin_password
               name: pact-broker-secrets
-        - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
-          valueFrom:
-            secretKeyRef:
-              key: pact_broker_user
-              name: pact-broker-secrets
-        - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: pact_broker_user_password
-              name: pact-broker-secrets
+        - name: PACT_BROKER_ALLOW_PUBLIC_READ
+          value: "true"
         - name: PACT_BROKER_DATABASE_HOST
           value: postgresql-pact-broker
         - name: PACT_BROKER_DATABASE_NAME


### PR DESCRIPTION
Allow public read access for the Pacts in the Pact broker. That will also allow downloading contracts without authentication. It should ease the Pact broker usage during PR checks.
https://issues.redhat.com/browse/HAC-5489