### PR TITLE
fix(typo): fix typo in check for postresql-tls

### DIFF
--- a/hack/secret-creator/create-plnsvc-secrets.sh
+++ b/hack/secret-creator/create-plnsvc-secrets.sh
@@ -67,7 +67,7 @@ EOF
 
 create_db_cert_secret_and_configmap() {
     echo "Creating Postgres TLS certs" >&2
-    if kubectl get secret -n tekton_results postgresql-tls &>/dev/null; then
+    if kubectl get secret -n tekton-results postgresql-tls &>/dev/null; then
         echo "Postgres DB cert secret already exists, skipping creation"
         return
     fi


### PR DESCRIPTION
Due to this typo, the bootstrap script can't be used to upgrade an already installed instance of Konflux.

example of job logs: https://github.com/redhat-hac-qe/infra-deployments/actions/runs/9639569500/job/26581952807