### PR TITLE
fix: add GOBIN to PATH 

### DIFF
--- a/.github/workflows/bootstrap-cluster.yml
+++ b/.github/workflows/bootstrap-cluster.yml
@@ -65,6 +65,8 @@ jobs:
           sed -i "s/IMAGE_CONTROLLER_QUAY_ORG=.*/IMAGE_CONTROLLER_QUAY_ORG=${IMAGE_CONTROLLER_QUAY_ORG}/g" hack/preview.env
           sed -i "s/IMAGE_CONTROLLER_QUAY_TOKEN=.*/IMAGE_CONTROLLER_QUAY_TOKEN=${IMAGE_CONTROLLER_QUAY_TOKEN}/g" hack/preview.env
 
+          export PATH=${PATH}:/home/runner/go/bin
+
           # Bootstrap the cluster
           hack/bootstrap-cluster.sh preview --toolchain --keycloak
           


### PR DESCRIPTION
To unblock us from latest changes in toolchain plugin, add GOBIN to the PATH.

Related PRs:
https://github.com/codeready-toolchain/toolchain-e2e/pull/1030
https://github.com/redhat-appstudio/infra-deployments/pull/4324